### PR TITLE
カーソルをマウスストーカーにして実装

### DIFF
--- a/2022.02.14_ハッカソン/ayumi/index.html
+++ b/2022.02.14_ハッカソン/ayumi/index.html
@@ -24,6 +24,10 @@
 </head>
 
 <body>
+  <!-- マウスストーカーの設置 -->
+  <div id ="stalker">
+    
+  </div>
   <div class="first-view">
     <!-- ヘッダー -->
     <header class="header">
@@ -60,7 +64,6 @@
     <div id="liner">
       <p class="border"></p>
     </div>
-   
     <!-- <hr> -->
     <p>
       <a href="https://1-notes.com/css-border-animation/" target="_blank" rel="noopener"></a>

--- a/2022.02.14_ハッカソン/css/ayumu.css
+++ b/2022.02.14_ハッカソン/css/ayumu.css
@@ -1,3 +1,23 @@
+/* マウスカーソルの非表示 */
+*{
+    cursor:none !important;
+}
+/* マウスストーカーのデザイン */
+#stalker {
+    pointer-events: none;
+    position: fixed;
+    top: -50px;     
+    left: -50px;    
+    width: 100px;   
+    height: 100px; 
+    background: rgba(239, 243, 241, 0.5);
+    border-radius: 50%;
+    transform: translate(0,0);
+    transition: transform 0.2s;  
+    transition-timing-function: ease-out;
+    z-index: 1003;
+}
+
 body {
     overflow-y: hidden;
 }
@@ -11,17 +31,15 @@ body {
     width: 100%;
     top: 45%;
 }
-  #liner {
+#liner {
     margin: 70px 20px;
-  }
-  
-  .border{
+}
+.border{
     position: relative;
     font-size: 18px;
     color: white;
-  }
-  
-  .border:before{
+}
+.border:before{
     content: '';
     position: absolute;
     left: 0;
@@ -29,8 +47,8 @@ body {
     width: 0;
     border-bottom: solid 2px rgb(255, 255, 255,0.7);
     animation: border_anim 3s linear infinite;
-  }
-  
+}
+
 @keyframes border_anim {
     0%{
     width: 0%;
@@ -55,7 +73,7 @@ body {
 }
 .photos-wrapper::-webkit-scrollbar{
     display: none;
-  }
+}
 .photo-item {
 	display: inline-block;
 	width: 50%;
@@ -191,4 +209,4 @@ body {
     -webkit-transform: translate(-50%, -50%);
     -ms-transform: translate(-50%, -50%);
 }
- }
+}

--- a/2022.02.14_ハッカソン/js/ayumi.js
+++ b/2022.02.14_ハッカソン/js/ayumi.js
@@ -1,0 +1,8 @@
+
+//マウスストーカー用のdivを取得
+const stalker = document.getElementById('stalker'); 
+
+ //上記のdivタグをマウスに追従させる処理
+document.addEventListener('mousemove', function (e) {
+    stalker.style.transform = 'translate(' + e.clientX + 'px, ' + e.clientY + 'px)';
+});


### PR DESCRIPTION


## 参照したissue番号
→# 33

## やったこと
* マウスカーソルを非表示にし、マウスストーカーを取り付けた。
  
## やらなかったこと
* 矢印をつけてガイドカーソルにできていない、時間上間に合わない可能性が高いので後に回す。

## できるようになること（ユーザ目線）

* 少し変わったマウスカーソルを楽しめる

## できなくなること（ユーザ目線）

* 無し

## そのほか追加に書きたいこと

